### PR TITLE
Add custom buffer support

### DIFF
--- a/include/h5.hpp
+++ b/include/h5.hpp
@@ -795,6 +795,7 @@ namespace h5
         }
 
 
+        // Calls `read` with buffer's underlying pointer.
         template<
             typename Buffer,
             typename Tr = h5::buffer_traits<Buffer>,
@@ -802,7 +803,21 @@ namespace h5
         >
         void read(Buffer& buffer)
         {
-            Tr::reshape(buffer, this->shape());
+            read(Tr::data(buffer), Tr::shape(buffer));
+        }
+
+
+        // Reads all data from the dataset, resizing buffer to the shape of the
+        // dataset. See `read` for details. The buffer traits needs to support
+        // `reshape` operation.
+        template<
+            typename Buffer,
+            typename Tr = h5::buffer_traits<Buffer>,
+            typename T = typename Tr::value_type
+        >
+        void read_fit(Buffer& buffer)
+        {
+            Tr::reshape(buffer, shape());
             read(Tr::data(buffer), Tr::shape(buffer));
         }
 
@@ -857,6 +872,7 @@ namespace h5
         }
 
 
+        // Calls `write` with buffer's underlying pointer.
         template<
             typename Buffer,
             typename Tr = h5::buffer_traits<Buffer>,
@@ -868,6 +884,7 @@ namespace h5
         }
 
 
+        // Calls `write` with buffer's underlying pointer.
         template<
             typename Buffer,
             typename Tr = h5::buffer_traits<Buffer>,

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -32,7 +32,8 @@ OBJECTS = \
   test_unique_hid.o \
   test_shape.o \
   test_file.o \
-  test_dataset.o
+  test_dataset.o \
+  test_buffer.o
 
 
 .PHONY: run clean
@@ -54,3 +55,4 @@ test_unique_hid.o: test_unique_hid.cc ../include/h5.hpp
 test_shape.o: test_shape.cc ../include/h5.hpp
 test_file.o: test_file.cc utils.hpp ../include/h5.hpp
 test_dataset.o: test_dataset.cc utils.hpp ../include/h5.hpp
+test_buffer.o: test_buffer.cc utils.hpp ../include/h5.hpp

--- a/tests/test_buffer.cc
+++ b/tests/test_buffer.cc
@@ -15,14 +15,28 @@ namespace
         double y;
         double z;
     };
-    static_assert(sizeof(triple_row) == 3 * sizeof(double), "unexpected padding");
+
+    bool operator==(triple_row const& r1, triple_row const& r2)
+    {
+        return r1.x == r2.x && r1.y == r2.y && r1.z == r2.z;
+    }
+
+    bool operator!=(triple_row const& r1, triple_row const& r2)
+    {
+        return !(r1 == r2);
+    }
 }
 
 namespace h5
 {
+    // Vector of triple_row objects as a two-dimensional n-by-3 array.
     template<>
     struct buffer_traits<std::vector<triple_row>>
     {
+        static_assert(
+            sizeof(triple_row) == 3 * sizeof(double), "unexpected padding"
+        );
+
         using buffer_type = std::vector<triple_row>;
         using value_type = double;
         static constexpr int rank = 2;
@@ -50,47 +64,48 @@ namespace h5
 }
 
 
-TEST_CASE("dataset::read - accepts vector buffer")
+TEST_CASE("dataset::write/read - accepts vector buffer")
 {
     temporary tmp;
-    copy("data/sample.h5", tmp.filename);
-
-    h5::file file(tmp.filename, "r");
-
-    std::vector<int> const expect = {
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9
-    };
-    h5::dataset<int, 1> dataset = file.dataset<int, 1>("simple/int_1");
-    REQUIRE(dataset);
-    REQUIRE(dataset.shape() == h5::shape<1>{10});
-
-    std::vector<int> buffer;
-    dataset.read(buffer);
-    CHECK(buffer == expect);
-}
-
-TEST_CASE("dataset::write - accepts vector buffer")
-{
-    temporary tmp;
-    copy("data/sample.h5", tmp.filename);
 
     h5::file file(tmp.filename, "w");
 
-    h5::dataset<float, 1> dataset = file.dataset<float, 1>("data/foo/bar");
+    // Write
+
+    h5::dataset<float, 1> dataset = file.dataset<float, 1>("data");
     std::vector<float> const data = {1, 2, 3, 4, 5};
     dataset.write(data);
 
     CHECK(dataset.shape().dims[0] == data.size());
+
+    // Read
+
+    SECTION("dataset::read - reads custom vector buffer")
+    {
+        std::vector<float> buffer(dataset.shape().dims[0]);
+        dataset.read(buffer);
+
+        CHECK(buffer == data);
+    }
+
+    SECTION("dataset::read_fit - reads custom vector buffer")
+    {
+        std::vector<float> buffer;
+        dataset.read_fit(buffer);
+
+        CHECK(buffer == data);
+    }
 }
 
-TEST_CASE("dataset::write - accepts custom vector buffer")
+TEST_CASE("dataset::write/read - accepts custom vector buffer")
 {
     temporary tmp;
-    copy("data/sample.h5", tmp.filename);
 
     h5::file file(tmp.filename, "w");
 
-    h5::dataset<double, 2> dataset = file.dataset<double, 2>("data/foo/bar");
+    // Write
+
+    h5::dataset<double, 2> dataset = file.dataset<double, 2>("data");
     std::vector<triple_row> const data = {
         {1, 2, 3},
         {4, 5, 6},
@@ -100,4 +115,22 @@ TEST_CASE("dataset::write - accepts custom vector buffer")
 
     CHECK(dataset.shape().dims[0] == data.size());
     CHECK(dataset.shape().dims[1] == 3);
+
+    // Read
+
+    SECTION("dataset::read - reads custom vector buffer")
+    {
+        std::vector<triple_row> buffer(dataset.shape().dims[0]);
+        dataset.read(buffer);
+
+        CHECK(buffer == data);
+    }
+
+    SECTION("dataset::read_fit - reads custom vector buffer")
+    {
+        std::vector<triple_row> buffer;
+        dataset.read_fit(buffer);
+
+        CHECK(buffer == data);
+    }
 }

--- a/tests/test_buffer.cc
+++ b/tests/test_buffer.cc
@@ -1,0 +1,103 @@
+#include <vector>
+
+#include <h5.hpp>
+
+#include <catch.hpp>
+
+#include "utils.hpp"
+
+
+namespace
+{
+    struct triple_row
+    {
+        double x;
+        double y;
+        double z;
+    };
+    static_assert(sizeof(triple_row) == 3 * sizeof(double), "unexpected padding");
+}
+
+namespace h5
+{
+    template<>
+    struct buffer_traits<std::vector<triple_row>>
+    {
+        using buffer_type = std::vector<triple_row>;
+        using value_type = double;
+        static constexpr int rank = 2;
+
+        static h5::shape<rank> shape(buffer_type const& buffer)
+        {
+            return {buffer.size(), 3};
+        }
+
+        static void reshape(buffer_type& buffer, h5::shape<rank> const& shape)
+        {
+            buffer.resize(shape.dims[0]);
+        }
+
+        static value_type* data(buffer_type& buffer)
+        {
+            return reinterpret_cast<value_type*>(buffer.data());
+        }
+
+        static value_type const* data(buffer_type const& buffer)
+        {
+            return reinterpret_cast<value_type const*>(buffer.data());
+        }
+    };
+}
+
+
+TEST_CASE("dataset::read - accepts vector buffer")
+{
+    temporary tmp;
+    copy("data/sample.h5", tmp.filename);
+
+    h5::file file(tmp.filename, "r");
+
+    std::vector<int> const expect = {
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+    };
+    h5::dataset<int, 1> dataset = file.dataset<int, 1>("simple/int_1");
+    REQUIRE(dataset);
+    REQUIRE(dataset.shape() == h5::shape<1>{10});
+
+    std::vector<int> buffer;
+    dataset.read(buffer);
+    CHECK(buffer == expect);
+}
+
+TEST_CASE("dataset::write - accepts vector buffer")
+{
+    temporary tmp;
+    copy("data/sample.h5", tmp.filename);
+
+    h5::file file(tmp.filename, "w");
+
+    h5::dataset<float, 1> dataset = file.dataset<float, 1>("data/foo/bar");
+    std::vector<float> const data = {1, 2, 3, 4, 5};
+    dataset.write(data);
+
+    CHECK(dataset.shape().dims[0] == data.size());
+}
+
+TEST_CASE("dataset::write - accepts custom vector buffer")
+{
+    temporary tmp;
+    copy("data/sample.h5", tmp.filename);
+
+    h5::file file(tmp.filename, "w");
+
+    h5::dataset<double, 2> dataset = file.dataset<double, 2>("data/foo/bar");
+    std::vector<triple_row> const data = {
+        {1, 2, 3},
+        {4, 5, 6},
+        {7, 8, 9},
+    };
+    dataset.write(data);
+
+    CHECK(dataset.shape().dims[0] == data.size());
+    CHECK(dataset.shape().dims[1] == 3);
+}


### PR DESCRIPTION
Reading/writing dataset via raw pointer to a flattened memory is cumbersome. Let's support direct read/write of `std::vector` and custom buffers.

## Buffer traits

`Tr = buffer_traits<Buffer>` should expose these members:

```
Tr::value_type  // type of each value
Tr::rank  // rank of the buffer
Tr::data(buffer)  // pointer to the underlying memory
Tr::shape(buffer)  // shape of the buffer
Tr::reshape(buffer, shape)  // (optional) reshape buffer to specified shape
```

A reference implementation for `std::vector` is provided.

## Added APIs

```
dataset::read(buffer)
dataset::read_fit(buffer)
dataset::write(buffer)
dataset::write(buffer, options)
```

`read` validates buffer shape against dataset shape, whereas `read_fit` reshapes buffer to fit to the dataset to read.